### PR TITLE
Add PlayerProfile support to PaperLib

### DIFF
--- a/src/main/java/io/papermc/lib/PaperLib.java
+++ b/src/main/java/io/papermc/lib/PaperLib.java
@@ -160,8 +160,8 @@ public class PaperLib {
      * @throws IOException if there was a rate-limit or other network error
      */
     @Nonnull
-    public static CompletableFuture<UUID> getPlayerUUIDAsync(@Nonnull String playerName) throws IOException {
-        return ENVIRONMENT.getPlayerUUIDAsync(playerName);
+    public static CompletableFuture<UUID> getPlayerUUID(@Nonnull String playerName) throws IOException {
+        return ENVIRONMENT.getPlayerUUID(playerName);
     }
 
     /**
@@ -175,8 +175,8 @@ public class PaperLib {
      * @throws IOException if there was a rate-limit or other network error
      */
     @Nonnull
-    public static CompletableFuture<String> getPlayerNameAsync(@Nonnull UUID playerUUID) throws IOException {
-        return ENVIRONMENT.getPlayerNameAsync(playerUUID);
+    public static CompletableFuture<String> getPlayerName(@Nonnull UUID playerUUID) throws IOException {
+        return ENVIRONMENT.getPlayerName(playerUUID);
     }
 
     /**

--- a/src/main/java/io/papermc/lib/PaperLib.java
+++ b/src/main/java/io/papermc/lib/PaperLib.java
@@ -13,6 +13,8 @@ import org.bukkit.entity.Entity;
 import org.bukkit.plugin.Plugin;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 
@@ -145,6 +147,36 @@ public class PaperLib {
     @Nonnull
     public static BlockStateSnapshotResult getBlockState(@Nonnull Block block, boolean useSnapshot) {
         return ENVIRONMENT.getBlockState(block, useSnapshot);
+    }
+
+    /**
+     * Returns the UUID of a player found by name, or null
+     * if a player was not found by the name provided.
+     * If there was a rate-limit or other network error,
+     * an IOException will be thrown.
+     *
+     * @param playerName The name of the player to fetch
+     * @return The UUID of the specified player, or null if not found
+     * @throws IOException if there was a rate-limit or other network error
+     */
+    @Nonnull
+    public static CompletableFuture<UUID> getPlayerUUIDAsync(@Nonnull String playerName) throws IOException {
+        return ENVIRONMENT.getPlayerUUIDAsync(playerName);
+    }
+
+    /**
+     * Returns the name of a player found by UUID, or null
+     * if a player was not found by the UUID provided.
+     * If there was a rate-limit or other network error,
+     * an IOException will be thrown.
+     *
+     * @param playerUUID The UUID of the player to fetch
+     * @return The name of the specified player, or null if not found
+     * @throws IOException if there was a rate-limit or other network error
+     */
+    @Nonnull
+    public static CompletableFuture<String> getPlayerNameAsync(@Nonnull UUID playerUUID) throws IOException {
+        return ENVIRONMENT.getPlayerNameAsync(playerUUID);
     }
 
     /**

--- a/src/main/java/io/papermc/lib/environments/Environment.java
+++ b/src/main/java/io/papermc/lib/environments/Environment.java
@@ -11,6 +11,8 @@ import io.papermc.lib.features.blockstatesnapshot.BlockStateSnapshotBeforeSnapsh
 import io.papermc.lib.features.chunkisgenerated.ChunkIsGenerated;
 import io.papermc.lib.features.chunkisgenerated.ChunkIsGeneratedApiExists;
 import io.papermc.lib.features.chunkisgenerated.ChunkIsGeneratedUnknown;
+import io.papermc.lib.features.profilesupport.ProfileSupport;
+import io.papermc.lib.features.profilesupport.ProfileSupportUnknown;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -18,6 +20,8 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 
+import java.io.IOException;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
@@ -32,6 +36,7 @@ public abstract class Environment {
     protected AsyncChunks asyncChunksHandler = new AsyncChunksSync();
     protected AsyncTeleport asyncTeleportHandler = new AsyncTeleportSync();
     protected ChunkIsGenerated isGeneratedHandler = new ChunkIsGeneratedUnknown();
+    protected ProfileSupport profileSupportHandler = new ProfileSupportUnknown();
     protected BlockStateSnapshot blockStateSnapshotHandler;
 
     public Environment() {
@@ -84,6 +89,14 @@ public abstract class Environment {
 
     public BlockStateSnapshotResult getBlockState(Block block, boolean useSnapshot) {
         return blockStateSnapshotHandler.getBlockState(block, useSnapshot);
+    }
+
+    public CompletableFuture<UUID> getPlayerUUIDAsync(String playerName) throws IOException {
+        return profileSupportHandler.getPlayerUUIDAsync(playerName);
+    }
+
+    public CompletableFuture<String> getPlayerNameAsync(UUID playerUUID) throws IOException {
+        return profileSupportHandler.getPlayerNameAsync(playerUUID);
     }
 
     public boolean isVersion(int minor) {

--- a/src/main/java/io/papermc/lib/environments/Environment.java
+++ b/src/main/java/io/papermc/lib/environments/Environment.java
@@ -91,12 +91,12 @@ public abstract class Environment {
         return blockStateSnapshotHandler.getBlockState(block, useSnapshot);
     }
 
-    public CompletableFuture<UUID> getPlayerUUIDAsync(String playerName) throws IOException {
-        return profileSupportHandler.getPlayerUUIDAsync(playerName);
+    public CompletableFuture<UUID> getPlayerUUID(String playerName) throws IOException {
+        return profileSupportHandler.getPlayerUUID(playerName);
     }
 
-    public CompletableFuture<String> getPlayerNameAsync(UUID playerUUID) throws IOException {
-        return profileSupportHandler.getPlayerNameAsync(playerUUID);
+    public CompletableFuture<String> getPlayerName(UUID playerUUID) throws IOException {
+        return profileSupportHandler.getPlayerName(playerUUID);
     }
 
     public boolean isVersion(int minor) {

--- a/src/main/java/io/papermc/lib/environments/PaperEnvironment.java
+++ b/src/main/java/io/papermc/lib/environments/PaperEnvironment.java
@@ -5,6 +5,7 @@ import io.papermc.lib.features.asyncchunks.AsyncChunksPaper_9_12;
 import io.papermc.lib.features.asyncteleport.AsyncTeleportPaper;
 import io.papermc.lib.features.blockstatesnapshot.BlockStateSnapshotOptionalSnapshots;
 import io.papermc.lib.features.chunkisgenerated.ChunkIsGeneratedApiExists;
+import io.papermc.lib.features.profilesupport.ProfileSupportPaper;
 
 public class PaperEnvironment extends SpigotEnvironment {
 
@@ -22,6 +23,7 @@ public class PaperEnvironment extends SpigotEnvironment {
             // Paper added this API in 1.12 with same signature spigot did in 1.13
             isGeneratedHandler = new ChunkIsGeneratedApiExists();
             blockStateSnapshotHandler = new BlockStateSnapshotOptionalSnapshots();
+            profileSupportHandler = new ProfileSupportPaper();
         }
     }
 

--- a/src/main/java/io/papermc/lib/features/profilesupport/ProfileSupport.java
+++ b/src/main/java/io/papermc/lib/features/profilesupport/ProfileSupport.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public interface ProfileSupport {
-    CompletableFuture<UUID> getPlayerUUIDAsync(String playerName) throws IOException;
+    CompletableFuture<UUID> getPlayerUUID(String playerName) throws IOException;
 
-    CompletableFuture<String> getPlayerNameAsync(UUID playerUUID) throws IOException;
+    CompletableFuture<String> getPlayerName(UUID playerUUID) throws IOException;
 }

--- a/src/main/java/io/papermc/lib/features/profilesupport/ProfileSupport.java
+++ b/src/main/java/io/papermc/lib/features/profilesupport/ProfileSupport.java
@@ -1,0 +1,11 @@
+package io.papermc.lib.features.profilesupport;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public interface ProfileSupport {
+    CompletableFuture<UUID> getPlayerUUIDAsync(String playerName) throws IOException;
+
+    CompletableFuture<String> getPlayerNameAsync(UUID playerUUID) throws IOException;
+}

--- a/src/main/java/io/papermc/lib/features/profilesupport/ProfileSupportPaper.java
+++ b/src/main/java/io/papermc/lib/features/profilesupport/ProfileSupportPaper.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public class ProfileSupportPaper implements ProfileSupport {
-    public CompletableFuture<UUID> getPlayerUUIDAsync(String playerName) throws IOException {
+    public CompletableFuture<UUID> getPlayerUUID(String playerName) throws IOException {
         PlayerProfile profile = Bukkit.createProfile(playerName);
         if (profile.isComplete() || profile.completeFromCache()) {
             return CompletableFuture.completedFuture(profile.getId());
@@ -20,7 +20,7 @@ public class ProfileSupportPaper implements ProfileSupport {
         });
     }
 
-    public CompletableFuture<String> getPlayerNameAsync(UUID playerUUID) throws IOException {
+    public CompletableFuture<String> getPlayerName(UUID playerUUID) throws IOException {
         PlayerProfile profile = Bukkit.createProfile(playerUUID);
         if (profile.isComplete() || profile.completeFromCache()) {
             return CompletableFuture.completedFuture(profile.getName());

--- a/src/main/java/io/papermc/lib/features/profilesupport/ProfileSupportPaper.java
+++ b/src/main/java/io/papermc/lib/features/profilesupport/ProfileSupportPaper.java
@@ -1,0 +1,34 @@
+package io.papermc.lib.features.profilesupport;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+import org.bukkit.Bukkit;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class ProfileSupportPaper implements ProfileSupport {
+    public CompletableFuture<UUID> getPlayerUUIDAsync(String playerName) throws IOException {
+        PlayerProfile profile = Bukkit.createProfile(playerName);
+        if (profile.isComplete() || profile.completeFromCache()) {
+            return CompletableFuture.completedFuture(profile.getId());
+        }
+
+        return CompletableFuture.supplyAsync(() -> {
+            profile.complete(false);
+            return profile.getId();
+        });
+    }
+
+    public CompletableFuture<String> getPlayerNameAsync(UUID playerUUID) throws IOException {
+        PlayerProfile profile = Bukkit.createProfile(playerUUID);
+        if (profile.isComplete() || profile.completeFromCache()) {
+            return CompletableFuture.completedFuture(profile.getName());
+        }
+
+        return CompletableFuture.supplyAsync(() -> {
+            profile.complete(false);
+            return profile.getName();
+        });
+    }
+}

--- a/src/main/java/io/papermc/lib/features/profilesupport/ProfileSupportUnknown.java
+++ b/src/main/java/io/papermc/lib/features/profilesupport/ProfileSupportUnknown.java
@@ -1,0 +1,17 @@
+package io.papermc.lib.features.profilesupport;
+
+import org.bukkit.Bukkit;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class ProfileSupportUnknown implements ProfileSupport {
+    public CompletableFuture<UUID> getPlayerUUIDAsync(String playerName) throws IOException {
+        return CompletableFuture.completedFuture(Bukkit.getOfflinePlayer(playerName).getUniqueId());
+    }
+
+    public CompletableFuture<String> getPlayerNameAsync(UUID playerUUID) throws IOException {
+        return CompletableFuture.completedFuture(Bukkit.getOfflinePlayer(playerUUID).getName());
+    }
+}

--- a/src/main/java/io/papermc/lib/features/profilesupport/ProfileSupportUnknown.java
+++ b/src/main/java/io/papermc/lib/features/profilesupport/ProfileSupportUnknown.java
@@ -7,11 +7,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public class ProfileSupportUnknown implements ProfileSupport {
-    public CompletableFuture<UUID> getPlayerUUIDAsync(String playerName) throws IOException {
+    public CompletableFuture<UUID> getPlayerUUID(String playerName) throws IOException {
         return CompletableFuture.completedFuture(Bukkit.getOfflinePlayer(playerName).getUniqueId());
     }
 
-    public CompletableFuture<String> getPlayerNameAsync(UUID playerUUID) throws IOException {
+    public CompletableFuture<String> getPlayerName(UUID playerUUID) throws IOException {
         return CompletableFuture.completedFuture(Bukkit.getOfflinePlayer(playerUUID).getName());
     }
 }


### PR DESCRIPTION
This adds PlayerProfile/UUID fetching support. Not much else to say, really.