### PR TITLE
Move suggestPaper to info (configurable level)

### DIFF
--- a/src/main/java/io/papermc/lib/PaperLib.java
+++ b/src/main/java/io/papermc/lib/PaperLib.java
@@ -270,24 +270,24 @@ public class PaperLib {
         final String benefitsProperty = "paperlib.shown-benefits";
         final String pluginName = plugin.getDescription().getName();
         final Logger logger = plugin.getLogger();
-        logger.warning("====================================================");
-        logger.warning(" " + pluginName + " works better if you use Paper ");
-        logger.warning(" as your server software. ");
+        logger.info("====================================================");
+        logger.info(" " + pluginName + " works better if you use Paper ");
+        logger.info(" as your server software. ");
         if (System.getProperty(benefitsProperty) == null) {
             System.setProperty(benefitsProperty, "1");
-            logger.warning("  ");
-            logger.warning(" Paper offers significant performance improvements,");
-            logger.warning(" bug fixes, security enhancements and optional");
-            logger.warning(" features for server owners to enhance their server.");
-            logger.warning("  ");
-            logger.warning(" Paper includes Timings v2, which is significantly");
-            logger.warning(" better at diagnosing lag problems over v1.");
-            logger.warning("  ");
-            logger.warning(" All of your plugins should still work, and the");
-            logger.warning(" Paper community will gladly help you fix any issues.");
-            logger.warning("  ");
-            logger.warning(" Join the Paper Community @ https://papermc.io");
+            logger.info("  ");
+            logger.info(" Paper offers significant performance improvements,");
+            logger.info(" bug fixes, security enhancements and optional");
+            logger.info(" features for server owners to enhance their server.");
+            logger.info("  ");
+            logger.info(" Paper includes Timings v2, which is significantly");
+            logger.info(" better at diagnosing lag problems over v1.");
+            logger.info("  ");
+            logger.info(" All of your plugins should still work, and the");
+            logger.info(" Paper community will gladly help you fix any issues.");
+            logger.info("  ");
+            logger.info(" Join the Paper Community @ https://papermc.io");
         }
-        logger.warning("====================================================");
+        logger.info("====================================================");
     }
 }

--- a/src/main/java/io/papermc/lib/PaperLib.java
+++ b/src/main/java/io/papermc/lib/PaperLib.java
@@ -16,6 +16,7 @@ import org.bukkit.plugin.Plugin;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -261,33 +262,49 @@ public class PaperLib {
      * If you do not mind helping spread Paper, please call this in your plugin onEnable to help spread
      * awareness about Paper, and encourage them that your plugin is better when used with Paper!
      *
+     * This passes the default logLevel of Level.INFO
+     *
      * @param plugin Your plugin object
+     * @see #suggestPaper(Plugin, Level) 
      */
     public static void suggestPaper(@Nonnull Plugin plugin) {
+        suggestPaper(plugin, Level.INFO);
+    }
+
+    /**
+     * Can be called during plugin initialization to inform the server owner they should switch to Paper
+     *
+     * If you do not mind helping spread Paper, please call this in your plugin onEnable to help spread
+     * awareness about Paper, and encourage them that your plugin is better when used with Paper!
+     *
+     * @param plugin Your plugin object
+     * @param logLevel The logLevel you want to choose
+     */
+    public static void suggestPaper(@Nonnull Plugin plugin, @Nonnull Level logLevel) {
         if (isPaper()) {
             return;
         }
         final String benefitsProperty = "paperlib.shown-benefits";
         final String pluginName = plugin.getDescription().getName();
         final Logger logger = plugin.getLogger();
-        logger.info("====================================================");
-        logger.info(" " + pluginName + " works better if you use Paper ");
-        logger.info(" as your server software. ");
+        logger.log(logLevel, "====================================================");
+        logger.log(logLevel, " " + pluginName + " works better if you use Paper ");
+        logger.log(logLevel, " as your server software. ");
         if (System.getProperty(benefitsProperty) == null) {
             System.setProperty(benefitsProperty, "1");
-            logger.info("  ");
-            logger.info(" Paper offers significant performance improvements,");
-            logger.info(" bug fixes, security enhancements and optional");
-            logger.info(" features for server owners to enhance their server.");
-            logger.info("  ");
-            logger.info(" Paper includes Timings v2, which is significantly");
-            logger.info(" better at diagnosing lag problems over v1.");
-            logger.info("  ");
-            logger.info(" All of your plugins should still work, and the");
-            logger.info(" Paper community will gladly help you fix any issues.");
-            logger.info("  ");
-            logger.info(" Join the Paper Community @ https://papermc.io");
+            logger.log(logLevel, "  ");
+            logger.log(logLevel, " Paper offers significant performance improvements,");
+            logger.log(logLevel, " bug fixes, security enhancements and optional");
+            logger.log(logLevel, " features for server owners to enhance their server.");
+            logger.log(logLevel, "  ");
+            logger.log(logLevel, " Paper includes Timings v2, which is significantly");
+            logger.log(logLevel, " better at diagnosing lag problems over v1.");
+            logger.log(logLevel, "  ");
+            logger.log(logLevel, " All of your plugins should still work, and the");
+            logger.log(logLevel, " Paper community will gladly help you fix any issues.");
+            logger.log(logLevel, "  ");
+            logger.log(logLevel, " Join the Paper Community @ https://papermc.io");
         }
-        logger.info("====================================================");
+        logger.log(logLevel, "====================================================");
     }
 }


### PR DESCRIPTION
I encourage the use of Paper and love the software myself, however, there are some situations (contracts, jobs, etc.), in which I need to use Spigot with plugins that use PaperLib. When developing, finding the warnings I'm looking for can made more inconvenient by the fact that this uses a warning logger.

I suggest we move these logs to info (a suggestion is a piece of information more than a warning anyway), to make things easier on developers who are stuck with Spigot.

Thanks.