### PR TITLE
Added support for getOfflinePlayer(String) with optional cache

### DIFF
--- a/src/main/java/io/papermc/lib/environments/Environment.java
+++ b/src/main/java/io/papermc/lib/environments/Environment.java
@@ -13,20 +13,26 @@ import io.papermc.lib.features.blockstatesnapshot.BlockStateSnapshotResult;
 import io.papermc.lib.features.chunkisgenerated.ChunkIsGenerated;
 import io.papermc.lib.features.chunkisgenerated.ChunkIsGeneratedApiExists;
 import io.papermc.lib.features.chunkisgenerated.ChunkIsGeneratedUnknown;
+import io.papermc.lib.features.offlineplayers.GetOfflinePlayer;
+import io.papermc.lib.features.offlineplayers.GetOfflinePlayerNoCacheOption;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
-import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 @SuppressWarnings("WeakerAccess")
 public abstract class Environment {
@@ -40,6 +46,7 @@ public abstract class Environment {
     protected ChunkIsGenerated isGeneratedHandler = new ChunkIsGeneratedUnknown();
     protected BlockStateSnapshot blockStateSnapshotHandler;
     protected BedSpawnLocation bedSpawnLocationHandler = new BedSpawnLocationSync();
+    protected GetOfflinePlayer getOfflinePlayerHandler = new GetOfflinePlayerNoCacheOption();
 
     public Environment() {
         Pattern versionPattern = Pattern.compile("\\(MC: (\\d)\\.(\\d+)\\.?(\\d+?)?(?: Pre-Release )?(\\d)?\\)");
@@ -111,6 +118,11 @@ public abstract class Environment {
 
     public CompletableFuture<Location> getBedSpawnLocationAsync(Player player, boolean isUrgent) {
         return bedSpawnLocationHandler.getBedSpawnLocationAsync(player, isUrgent);
+    }
+    
+    @Nullable
+    public OfflinePlayer getOfflinePlayer(@Nonnull String name, boolean makeWebRequest) {
+        return getOfflinePlayerHandler.getOfflinePlayer(name, makeWebRequest);
     }
 
     public boolean isVersion(int minor) {

--- a/src/main/java/io/papermc/lib/environments/PaperEnvironment.java
+++ b/src/main/java/io/papermc/lib/environments/PaperEnvironment.java
@@ -8,6 +8,8 @@ import io.papermc.lib.features.asyncteleport.AsyncTeleportPaper_13;
 import io.papermc.lib.features.bedspawnlocation.BedSpawnLocationPaper;
 import io.papermc.lib.features.blockstatesnapshot.BlockStateSnapshotOptionalSnapshots;
 import io.papermc.lib.features.chunkisgenerated.ChunkIsGeneratedApiExists;
+import io.papermc.lib.features.offlineplayers.GetOfflinePlayerCachedOption;
+
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.HumanEntity;
@@ -37,6 +39,9 @@ public class PaperEnvironment extends SpigotEnvironment {
                 HumanEntity.class.getDeclaredMethod("getPotentialBedLocation");
                 bedSpawnLocationHandler = new BedSpawnLocationPaper();
             } catch (NoSuchMethodException ignored) {}
+        }
+        if (isVersion(16, 4)) {
+            getOfflinePlayerHandler = new GetOfflinePlayerCachedOption();
         }
     }
 

--- a/src/main/java/io/papermc/lib/features/offlineplayers/GetOfflinePlayer.java
+++ b/src/main/java/io/papermc/lib/features/offlineplayers/GetOfflinePlayer.java
@@ -1,0 +1,11 @@
+package io.papermc.lib.features.offlineplayers;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.bukkit.OfflinePlayer;
+
+public interface GetOfflinePlayer {
+    @Nullable
+    OfflinePlayer getOfflinePlayer(@Nonnull String name, boolean makeWebRequest);
+}

--- a/src/main/java/io/papermc/lib/features/offlineplayers/GetOfflinePlayerCachedOption.java
+++ b/src/main/java/io/papermc/lib/features/offlineplayers/GetOfflinePlayerCachedOption.java
@@ -1,0 +1,19 @@
+package io.papermc.lib.features.offlineplayers;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+
+public class GetOfflinePlayerCachedOption implements GetOfflinePlayer {
+    @Override
+    @Nullable
+    public OfflinePlayer getOfflinePlayer(@Nonnull String name, boolean makeWebRequest) {
+        if (makeWebRequest) {
+            return Bukkit.getOfflinePlayer(name);
+        } else {
+            return Bukkit.getOfflinePlayerIfCached(name);
+        }
+    }
+}

--- a/src/main/java/io/papermc/lib/features/offlineplayers/GetOfflinePlayerNoCacheOption.java
+++ b/src/main/java/io/papermc/lib/features/offlineplayers/GetOfflinePlayerNoCacheOption.java
@@ -1,0 +1,15 @@
+package io.papermc.lib.features.offlineplayers;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+
+public class GetOfflinePlayerNoCacheOption implements GetOfflinePlayer {
+    @Override
+    @Nullable
+    public OfflinePlayer getOfflinePlayer(@Nonnull String name, boolean makeWebRequest) {
+        return Bukkit.getOfflinePlayer(name);
+    }
+}


### PR DESCRIPTION
https://github.com/PaperMC/Paper/pull/4687 has introduced the ability to get an `OfflinePlayer` by their name without making a web request.

To properly utilise this feature in a Spigot-compatible environment, we currently need to rely on an `isPaper` and a version check to even see whether one is able to optimize for that.
I think this is a perfect opportunity for a `PaperLib` implementation.

This is just a basic implementation which was done in a similar manner to how the `BlockStateSnapshot` is handled.
The boolean `makeWebRequest` determines whether a web request is allowed. In environments that do not support `Bukkit.getOfflinePlayerIfCached()`, this boolean is just ignored. Similar to how `BlockStateSnapshot` will ignore the `useSnapshot` boolean if unsupported.

Of course, the `Bukkit.getOfflinePlayerIfCached()` method will not be available in every single 1.16.4-compatible build of Paper I presume, but I am gonna assume the typical "old versions are not supported anyway" situation here for now.
Lemme know if there is anything that should be changed or documented.