### PR TITLE
Return false for isChunkGenerated with unknown API

### DIFF
--- a/src/main/java/io/papermc/lib/features/chunkisgenerated/ChunkIsGeneratedUnknown.java
+++ b/src/main/java/io/papermc/lib/features/chunkisgenerated/ChunkIsGeneratedUnknown.java
@@ -5,6 +5,6 @@ import org.bukkit.World;
 public class ChunkIsGeneratedUnknown implements ChunkIsGenerated {
     @Override
     public boolean isChunkGenerated(World world, int x, int z) {
-        return true;
+        return false;
     }
 }


### PR DESCRIPTION
Extremely minor change/nitpick but isChunkGenerated should not return true when the API cannot be detected --  for example, in the brief duration that the paper version could not be detected correctly (due to the existence of release candidate builds). This is generally a bad assumption to make and can lead to unexpected behavior in plugins.