### PR TITLE
Adds the possibility to use improved multi blockchange api of Paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ Allows you to optionally avoid taking a snapshot of a TileEntity in a BlockState
 false for the snapshot. In versions 1.12+ on Spigot, the snapshot will always be true. In Paper 1.12+, the snapshot will
 be whether or not you requested one in the API call.
 
+### sendMultiBlockChange
+```java
+public class PaperLib {
+  public static sendMultiBlockChange(Player player, @NotNull Map<Location, BlockData> blockChanges);
+  public static sendMultiBlockChange(Player player, @NotNull Map<Location, BlockData> blockChanges, boolean suppressLightUpdates);
+}
+```
+
+Allows you to use the optimized chunk section update method for bulk block changes.
+Falls back to Player#sendBlockChange when running Spigot or Paper < 1.18 
+
 ### suggestPaper
 ```java
 public class PaperLib {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ val jar by tasks.existing
 group = "io.papermc"
 version = "1.0.8-SNAPSHOT"
 
-val mcVersion = "1.17.1-R0.1-SNAPSHOT"
+val mcVersion = "1.18.2-R0.1-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/papermc/lib/environments/Environment.java
+++ b/src/main/java/io/papermc/lib/environments/Environment.java
@@ -19,10 +19,13 @@ import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.jetbrains.annotations.NotNull;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
@@ -123,6 +126,13 @@ public abstract class Environment {
 
     public CompletableFuture<Location> getBedSpawnLocationAsync(Player player, boolean isUrgent) {
         return bedSpawnLocationHandler.getBedSpawnLocationAsync(player, isUrgent);
+    }
+
+    public void sendMultiBlockChange(Player player, @NotNull Map<Location, BlockData> blockChanges) {
+        sendMultiBlockChange(player, blockChanges, false);
+    }
+    public void sendMultiBlockChange(Player player, @NotNull Map<Location, BlockData> blockChanges, boolean suppressLightUpdates) {
+        blockChanges.forEach(player::sendBlockChange);
     }
 
     public boolean isVersion(int minor) {

--- a/src/main/java/io/papermc/lib/environments/PaperEnvironment.java
+++ b/src/main/java/io/papermc/lib/environments/PaperEnvironment.java
@@ -10,7 +10,12 @@ import io.papermc.lib.features.blockstatesnapshot.BlockStateSnapshotOptionalSnap
 import io.papermc.lib.features.chunkisgenerated.ChunkIsGeneratedApiExists;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
 
 public class PaperEnvironment extends SpigotEnvironment {
 
@@ -37,6 +42,15 @@ public class PaperEnvironment extends SpigotEnvironment {
                 HumanEntity.class.getDeclaredMethod("getPotentialBedLocation");
                 bedSpawnLocationHandler = new BedSpawnLocationPaper();
             } catch (NoSuchMethodException ignored) {}
+        }
+    }
+
+    @Override
+    public void sendMultiBlockChange(Player player, @NotNull Map<Location, BlockData> blockChanges, boolean suppressLightUpdates) {
+        if(!isVersion(18)){
+            super.sendMultiBlockChange(player, blockChanges, suppressLightUpdates);
+        } else {
+            player.sendMultiBlockChange(blockChanges, suppressLightUpdates);
         }
     }
 


### PR DESCRIPTION
When running on Spigot or Paper < 1.18 it falls back to sendBlockChange