### PR TITLE
Add a method to get InventoryHolders without snapshots

### DIFF
--- a/src/main/java/io/papermc/lib/PaperLib.java
+++ b/src/main/java/io/papermc/lib/PaperLib.java
@@ -5,6 +5,7 @@ import io.papermc.lib.environments.Environment;
 import io.papermc.lib.environments.PaperEnvironment;
 import io.papermc.lib.environments.SpigotEnvironment;
 import io.papermc.lib.features.blockstatesnapshot.BlockStateSnapshotResult;
+import io.papermc.lib.features.inventoryholdersnapshot.InventoryHolderSnapshotResult;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -12,6 +13,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.Plugin;
 
 import javax.annotation.Nonnull;
@@ -194,6 +196,18 @@ public class PaperLib {
     @Nonnull
     public static BlockStateSnapshotResult getBlockState(@Nonnull Block block, boolean useSnapshot) {
         return ENVIRONMENT.getBlockState(block, useSnapshot);
+    }
+
+    /**
+     * Gets an InventoryHolder, optionally not using a snapshot
+     *
+     * @param inventory The inventory to get the holder of
+     * @param useSnapshot Whether to use a snapshot when supported
+     * @return The InventoryHolder
+     */
+    @Nonnull
+    public static InventoryHolderSnapshotResult getHolder(@Nonnull Inventory inventory, boolean useSnapshot) {
+        return ENVIRONMENT.getHolder(inventory, useSnapshot);
     }
 
     /**

--- a/src/main/java/io/papermc/lib/environments/Environment.java
+++ b/src/main/java/io/papermc/lib/environments/Environment.java
@@ -14,6 +14,11 @@ import io.papermc.lib.features.chunkisgenerated.ChunkIsGenerated;
 import io.papermc.lib.features.chunkisgenerated.ChunkIsGeneratedApiExists;
 import io.papermc.lib.features.chunkisgenerated.ChunkIsGeneratedUnknown;
 import java.util.Locale;
+
+import io.papermc.lib.features.inventoryholdersnapshot.InventoryHolderSnapshot;
+import io.papermc.lib.features.inventoryholdersnapshot.InventoryHolderSnapshotBeforeSnapshots;
+import io.papermc.lib.features.inventoryholdersnapshot.InventoryHolderSnapshotNoOption;
+import io.papermc.lib.features.inventoryholdersnapshot.InventoryHolderSnapshotResult;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -22,6 +27,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.bukkit.inventory.Inventory;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.MatchResult;
@@ -40,6 +46,7 @@ public abstract class Environment {
     protected AsyncTeleport asyncTeleportHandler = new AsyncTeleportSync();
     protected ChunkIsGenerated isGeneratedHandler = new ChunkIsGeneratedUnknown();
     protected BlockStateSnapshot blockStateSnapshotHandler;
+    protected InventoryHolderSnapshot inventoryHolderSnapshotHandler;
     protected BedSpawnLocation bedSpawnLocationHandler = new BedSpawnLocationSync();
 
     public Environment() {
@@ -90,8 +97,10 @@ public abstract class Environment {
         }
         if (!isVersion(12)) {
             blockStateSnapshotHandler = new BlockStateSnapshotBeforeSnapshots();
+            inventoryHolderSnapshotHandler = new InventoryHolderSnapshotBeforeSnapshots();
         } else {
             blockStateSnapshotHandler = new BlockStateSnapshotNoOption();
+            inventoryHolderSnapshotHandler = new InventoryHolderSnapshotNoOption();
         }
     }
 
@@ -119,6 +128,10 @@ public abstract class Environment {
 
     public BlockStateSnapshotResult getBlockState(Block block, boolean useSnapshot) {
         return blockStateSnapshotHandler.getBlockState(block, useSnapshot);
+    }
+
+    public InventoryHolderSnapshotResult getHolder(Inventory inventory, boolean useSnapshot) {
+        return inventoryHolderSnapshotHandler.getHolder(inventory, useSnapshot);
     }
 
     public CompletableFuture<Location> getBedSpawnLocationAsync(Player player, boolean isUrgent) {

--- a/src/main/java/io/papermc/lib/environments/PaperEnvironment.java
+++ b/src/main/java/io/papermc/lib/environments/PaperEnvironment.java
@@ -8,6 +8,7 @@ import io.papermc.lib.features.asyncteleport.AsyncTeleportPaper_13;
 import io.papermc.lib.features.bedspawnlocation.BedSpawnLocationPaper;
 import io.papermc.lib.features.blockstatesnapshot.BlockStateSnapshotOptionalSnapshots;
 import io.papermc.lib.features.chunkisgenerated.ChunkIsGeneratedApiExists;
+import io.papermc.lib.features.inventoryholdersnapshot.InventoryHolderSnapshotOptionalSnapshots;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.HumanEntity;
@@ -37,6 +38,9 @@ public class PaperEnvironment extends SpigotEnvironment {
                 HumanEntity.class.getDeclaredMethod("getPotentialBedLocation");
                 bedSpawnLocationHandler = new BedSpawnLocationPaper();
             } catch (NoSuchMethodException ignored) {}
+        }
+        if (isVersion(16)) {
+            inventoryHolderSnapshotHandler = new InventoryHolderSnapshotOptionalSnapshots();
         }
     }
 

--- a/src/main/java/io/papermc/lib/features/inventoryholdersnapshot/InventoryHolderSnapshot.java
+++ b/src/main/java/io/papermc/lib/features/inventoryholdersnapshot/InventoryHolderSnapshot.java
@@ -1,0 +1,7 @@
+package io.papermc.lib.features.inventoryholdersnapshot;
+
+import org.bukkit.inventory.Inventory;
+
+public interface InventoryHolderSnapshot {
+    InventoryHolderSnapshotResult getHolder(Inventory inventory, boolean useSnapshot);
+}

--- a/src/main/java/io/papermc/lib/features/inventoryholdersnapshot/InventoryHolderSnapshotBeforeSnapshots.java
+++ b/src/main/java/io/papermc/lib/features/inventoryholdersnapshot/InventoryHolderSnapshotBeforeSnapshots.java
@@ -1,0 +1,14 @@
+package io.papermc.lib.features.inventoryholdersnapshot;
+
+import org.bukkit.inventory.Inventory;
+
+/**
+ * Block State Snapshots was added in 1.12, this will always be no snapshots
+ */
+public class InventoryHolderSnapshotBeforeSnapshots implements InventoryHolderSnapshot {
+
+    @Override
+    public InventoryHolderSnapshotResult getHolder(Inventory inventory, boolean useSnapshot) {
+        return new InventoryHolderSnapshotResult(false, inventory.getHolder());
+    }
+}

--- a/src/main/java/io/papermc/lib/features/inventoryholdersnapshot/InventoryHolderSnapshotNoOption.java
+++ b/src/main/java/io/papermc/lib/features/inventoryholdersnapshot/InventoryHolderSnapshotNoOption.java
@@ -1,0 +1,10 @@
+package io.papermc.lib.features.inventoryholdersnapshot;
+
+import org.bukkit.inventory.Inventory;
+
+public class InventoryHolderSnapshotNoOption implements InventoryHolderSnapshot {
+    @Override
+    public InventoryHolderSnapshotResult getHolder(Inventory inventory, boolean useSnapshot) {
+        return new InventoryHolderSnapshotResult(true, inventory.getHolder());
+    }
+}

--- a/src/main/java/io/papermc/lib/features/inventoryholdersnapshot/InventoryHolderSnapshotOptionalSnapshots.java
+++ b/src/main/java/io/papermc/lib/features/inventoryholdersnapshot/InventoryHolderSnapshotOptionalSnapshots.java
@@ -1,0 +1,10 @@
+package io.papermc.lib.features.inventoryholdersnapshot;
+
+import org.bukkit.inventory.Inventory;
+
+public class InventoryHolderSnapshotOptionalSnapshots implements InventoryHolderSnapshot {
+    @Override
+    public InventoryHolderSnapshotResult getHolder(Inventory inventory, boolean useSnapshot) {
+        return new InventoryHolderSnapshotResult(useSnapshot, inventory.getHolder(useSnapshot));
+    }
+}

--- a/src/main/java/io/papermc/lib/features/inventoryholdersnapshot/InventoryHolderSnapshotResult.java
+++ b/src/main/java/io/papermc/lib/features/inventoryholdersnapshot/InventoryHolderSnapshotResult.java
@@ -1,0 +1,20 @@
+package io.papermc.lib.features.inventoryholdersnapshot;
+
+import org.bukkit.inventory.InventoryHolder;
+public class InventoryHolderSnapshotResult {
+    private final boolean isSnapshot;
+    private final InventoryHolder holder;
+
+    public InventoryHolderSnapshotResult(boolean isSnapshot, InventoryHolder holder) {
+        this.isSnapshot = isSnapshot;
+        this.holder = holder;
+    }
+
+    public boolean isSnapshot() {
+        return isSnapshot;
+    }
+
+    public InventoryHolder getHolder() {
+        return holder;
+    }
+}


### PR DESCRIPTION
This adds a method to PaperLib to get the InventoryHolder without a snapshot, as added by https://github.com/PaperMC/Paper/pull/3535. This PR was added a day before 1.16 released, so I've version gated it to 1.16